### PR TITLE
Added XDG desktop entry and Appstream metainfo XML.

### DIFF
--- a/data/misc/com.github.kentdahl.magic_maze.desktop
+++ b/data/misc/com.github.kentdahl.magic_maze.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Magicmaze
+Comment=rescue the maiden while avoiding the monsters
+Comment[de]=Rette das Burgfräulein und weiche den Monstern aus
+Comment[nb]=Redd jomfruen mens du unngår monstrene
+Exec=magicmaze
+Icon=magicmaze
+Terminal=false
+Categories=Game;ActionGame;
+Keywords=maiden;monsters;wizard;joystick;gauntlet;

--- a/data/misc/com.github.kentdahl.magic_maze.metainfo.xml
+++ b/data/misc/com.github.kentdahl.magic_maze.metainfo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.github.kentdahl.magic_maze</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>Magic Maze</name>
+  <summary>rescue the maiden while avoiding the monsters</summary>
+  <description>
+    <p>This is a simple game where you are a wizard searching the evil
+    demon's tower to try and rescue the beautiful maiden.  Inspired by
+    Gauntlet II, your goal is to avoid/kill the monsters while trying
+    to find the exit and, eventually, the big boss who is holding your
+    girlfriend captive.  Includes support for playing in full-screen
+    and with a joystick.</p>
+  </description>
+  <launchable type="desktop-id">com.github.kentdahl.magic_maze.desktop</launchable>
+  <url type="homepage">https://github.com/kentdahl/magic_maze</url>
+  <provides>
+    <binary>magicmaze</binary>
+  </provides>
+</component>


### PR DESCRIPTION
The two should be installed in /usr/share/applications/ and /usr/share/metainfo/ on a Linux machine.